### PR TITLE
Fix typing annotation

### DIFF
--- a/src/wavu/wavu_reader.py
+++ b/src/wavu/wavu_reader.py
@@ -1,6 +1,6 @@
 import json, requests, re, html
 
-from typing import List
+from typing import List, Optional
 from mediawiki import MediaWiki
 from src.module.character import Move
 from src.resources import const
@@ -159,7 +159,7 @@ def _remove_html_tags(data):
     return result
 
 link_replace_pattern = re.compile(r'\[\[(?P<page>[^#]+)#(?P<section>[^|]+)\|(?P<data>[^|]+)\]\]')
-def _process_links(data: str | None) -> str:
+def _process_links(data: Optional[str]) -> str:
     def _replace_link(match):
         page, section, data = match.group('page'), match.group('section'), match.group('data')
         hover_text = 'Combo' if section == 'Staples' else 'Mini-combo'


### PR DESCRIPTION
I run an instance of the bot in the containerized 3.9 environment, after rebasing with the master fork started seeing failures like
` TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'`

Seems to do with an invalid union type annotation. I updated it to use the standard Optional types instead