### PR TITLE
Fix nested Plainlist issue + link directly to move entry

### DIFF
--- a/src/module/embed.py
+++ b/src/module/embed.py
@@ -59,7 +59,7 @@ def move_embed(character: character, move: dict):
     embed = discord.Embed(title='**' + move['input'] + '**',
                           colour=SUCCESS_COLOR,
                           description=move['name'],
-                          url=character.wavu_page,
+                          url=f'{character.wavu_page}_movelist#{move["id"]}',
                           )
 
     embed.set_thumbnail(url=character.portrait[0])

--- a/src/wavu/wavu_reader.py
+++ b/src/wavu/wavu_reader.py
@@ -156,6 +156,7 @@ def _remove_html_tags(data):
     result = result.replace("* \n", "* ")
     result = re.sub(r"(\n)+", "\n", result)
     result = result.replace("'''", "")
+    result = result.replace('**', ' *') # hack/fix for nested Plainlists
     return result
 
 


### PR DESCRIPTION
First seen with Drag b+4,2,1+2, nested plainlists are not handled properly since Discord doesn't recognize the `** item` notation. It needs to be ` * item`.

I'm not sure whether this works for multiply nested plainlists. A more general solution + tests would probably be nice.

Secondly, this PR adds a link directly to the move entry for the move embed title instead of linking to the character page, which is already done in the character name included in the embed.