### PR TITLE
Fix issue with multi-word char names like Devil Jin

### DIFF
--- a/src/module/embed.py
+++ b/src/module/embed.py
@@ -59,12 +59,12 @@ def move_embed(character: character, move: dict):
     embed = discord.Embed(title='**' + move['input'] + '**',
                           colour=SUCCESS_COLOR,
                           description=move['name'],
-                          url=f'{character.wavu_page}_movelist#{move["id"]}',
+                          url=f'{character.wavu_page}_movelist#{move["id"].replace(" ", "_")}',
                           )
 
     embed.set_thumbnail(url=character.portrait[0])
     embed.set_footer(text="Wavu.wiki", icon_url=WAVU_LOGO)
-    embed.set_author(name=_upper_first_letter(character.name), url=character.wavu_page)
+    embed.set_author(name=_upper_first_letter(character.name.replace('_', ' ').title()), url=character.wavu_page)
 
     embed.add_field(name='Target', value=move['target'])
     embed.add_field(name='Damage', value=move['damage'])

--- a/src/wavu/wavu_reader.py
+++ b/src/wavu/wavu_reader.py
@@ -10,14 +10,6 @@ wavuwiki = MediaWiki(url=const.WAVU_API_URL)
 session = requests.Session()
 
 
-def _upper_first_letter(input: str) -> str:
-    if input:
-        result_string = input[0].capitalize() + input[1:]
-        return result_string
-    else:
-        return input
-
-
 def get_wavu_character_movelist(character_name: str) -> List[Move]:
     params = {
         "action": "cargoquery",
@@ -25,7 +17,7 @@ def get_wavu_character_movelist(character_name: str) -> List[Move]:
         "fields": "id,name,input,parent,target,damage,startup, recv, tot, crush, block,hit,ch,notes,_pageNamespace=ns",
         "join_on": "",
         "group_by": "",
-        "where": "id LIKE '" + _upper_first_letter(character_name) + "%'",
+        "where": "id LIKE '" + character_name.replace('_', ' ').title() + "%'",
         "having": "",
         "order_by": "id",
         "offset": "0",


### PR DESCRIPTION
Convert character names when querying cargo (replace `_` with space, convert to title case). Convert move IDs when using them in URLs by replacing spaces with `_`. Fixes #9 

This is quite a hacky solution again, and hopefully there aren't other characters like this.