### PR TITLE
Create move alts for strings recursively + fix spurious replies to messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ The bot supports the following slash commands -
 | Command | Description |
 | --- | --- |
 | `/fd <character> <move>` | Get frame data of a particular character's move |
+| `/<character>` | Get frame data for a particular character's move |
 | `/feedback <message>` | Send feedback to the bot owner |
+| `/help` | Get help on the bot's usage |
 
 ## Testing
 

--- a/src/frame_service/wavu/utils.py
+++ b/src/frame_service/wavu/utils.py
@@ -198,6 +198,13 @@ def _convert_wavu_movelist(movelist: List[WavuMove]) -> Dict[str, Move]:
             curr_id = stack.pop()
             curr_move = wavu_movelist[curr_id]
 
+            if len(curr_move.input) > 0 and curr_move.input[0] != ",":
+                curr_move.input = "," + curr_move.input
+            if len(curr_move.target) > 0 and curr_move.target[0] != ",":
+                curr_move.target = "," + curr_move.target
+            if len(curr_move.damage) > 0 and curr_move.damage[0] != ",":
+                curr_move.damage = "," + curr_move.damage
+
             curr_move.input = parent_input + curr_move.input
             curr_move.target = parent_target + curr_move.target
             curr_move.damage = parent_damage + curr_move.damage

--- a/src/framedb/framedb.py
+++ b/src/framedb/framedb.py
@@ -178,7 +178,9 @@ class FrameDb:
         move_list = self.frames[character].movelist.values()
         move_type = FrameDb._correct_move_type(move_type_query)
         if move_type:
-            moves = list(filter(lambda x: (move_type.value.lower() in x.notes.lower()), move_list))
+            moves = list(
+                filter(lambda x: (move_type.value.lower() in x.notes.lower()), move_list)
+            )  # TODO: revisit this logic for throws (and perhaps others)
         else:
             moves = []
 

--- a/src/heihachi/bot.py
+++ b/src/heihachi/bot.py
@@ -89,15 +89,15 @@ class FrameDataBot(discord.Client):
 
     async def on_message(self, message: discord.Message) -> None:
         if not self._is_user_blacklisted(message.author.id) and self.user and message.author.id != self.user.id:
-            if self.user.mentioned_in(message):
-                logger.info(f"Received message from {message.author.name} in {message.guild}: @Heihachi {message.content}")
-                try:
-                    user_command, params = message.content.split(" ", 1)
-                    char_name_query, move_query = params.split(" ", 1)
+            try:
+                user_command, params = message.content.split(" ", 1)
+                char_name_query, move_query = params.split(" ", 1)
+                if user_command == f"<@{self.user.id}>":
+                    logger.info(f"Received message from {message.author.name} in {message.guild}: {message.content}")
                     embed = get_frame_data_embed(self.framedb, self.frame_service, char_name_query, move_query)
                     await message.channel.send(embed=embed, reference=message)
-                except ValueError:
-                    logger.debug(f"Message from {message.author.name} in {message.guild} is not a valid command")
+            except ValueError:
+                logger.debug(f"Invalid command from {message.author.name} in {message.guild}: {message.content}")
 
     async def _character_name_autocomplete(
         self, interaction: discord.Interaction["FrameDataBot"], current: str


### PR DESCRIPTION
Add a feature to create move alts for strings while processing wavu movelists.

Also fix issues with the bot responding to replies to its messages, and to `@everyone` tags.